### PR TITLE
[tests] updated Catch lib: displaying tested value if failure

### DIFF
--- a/tests/TestCtcSegment.cpp
+++ b/tests/TestCtcSegment.cpp
@@ -17,7 +17,8 @@
 
 // using namespace std;
 using namespace ibex;
-
+using namespace Catch;
+using namespace Detail;
 
 
 TEST_CASE("test_contract_segment", "")

--- a/tests/catch/catch_interval.hpp
+++ b/tests/catch/catch_interval.hpp
@@ -18,77 +18,107 @@
 
 #include "ibex.h"
 
-
-class ApproxIntv
+namespace Catch
 {
-  public:
-    explicit ApproxIntv(ibex::Interval value) :
-        m_epsilon(std::numeric_limits<float>::epsilon()*10),
-        m_value(value)
-    {}
-
-    friend bool operator ==(ibex::Interval lhs, ApproxIntv const& rhs)
+  namespace Detail
+  {
+    class ApproxIntv
     {
-      double e = rhs.m_epsilon;
-      return lhs == rhs.m_value ||
-             (fabs(lhs.lb() - rhs.m_value.lb()) < e && fabs(lhs.ub() - rhs.m_value.ub()) < e);
-    }
+      public:
+        explicit ApproxIntv(ibex::Interval value) :
+            m_epsilon(std::numeric_limits<float>::epsilon()*10),
+            m_value(value)
+        {}
 
-    friend bool operator ==(ApproxIntv const& lhs, ibex::Interval rhs)
+        friend bool operator ==(ibex::Interval lhs, ApproxIntv const& rhs)
+        {
+          double e = rhs.m_epsilon;
+          return lhs == rhs.m_value ||
+                 (fabs(lhs.lb() - rhs.m_value.lb()) < e && fabs(lhs.ub() - rhs.m_value.ub()) < e);
+        }
+
+        friend bool operator ==(ApproxIntv const& lhs, ibex::Interval rhs)
+        {
+          return operator ==(rhs, lhs);
+        }
+
+        friend bool operator !=(ibex::Interval lhs, ApproxIntv const& rhs)
+        {
+          return !operator ==(lhs, rhs);
+        }
+
+        friend bool operator !=(ApproxIntv const& lhs, ibex::Interval rhs)
+        {
+          return !operator ==(rhs, lhs);
+        }
+
+        std::string toString() const
+        {
+          std::ostringstream oss;
+          oss << "Approx( " << Catch::toString(m_value) << " )";
+          return oss.str();
+        }
+
+      private:
+        double m_epsilon;
+        ibex::Interval m_value;
+    };
+
+    class ApproxIntvPair
     {
-      return operator ==(rhs, lhs);
-    }
+      public:
+        explicit ApproxIntvPair(std::pair<ibex::Interval,ibex::Interval> value) :
+            m_epsilon(std::numeric_limits<float>::epsilon()*10),
+            m_value(value)
+        {}
 
-    friend bool operator !=(ibex::Interval lhs, ApproxIntv const& rhs)
-    {
-      return !operator ==(lhs, rhs);
-    }
+        friend bool operator ==(std::pair<ibex::Interval,ibex::Interval> lhs, ApproxIntvPair const& rhs)
+        {
+          double e = rhs.m_epsilon;
+          return lhs == rhs.m_value ||
+                 (fabs(lhs.first.lb() - rhs.m_value.first.lb()) < e &&
+                  fabs(lhs.first.ub() - rhs.m_value.first.ub()) < e &&
+                  fabs(lhs.second.lb() - rhs.m_value.second.lb()) < e &&
+                  fabs(lhs.second.ub() - rhs.m_value.second.ub()) < e);
+        }
 
-    friend bool operator !=(ApproxIntv const& lhs, ibex::Interval rhs)
-    {
-      return !operator ==(rhs, lhs);
-    }
+        friend bool operator ==(ApproxIntvPair const& lhs, std::pair<ibex::Interval,ibex::Interval> rhs)
+        {
+          return operator ==(rhs, lhs);
+        }
 
-  private:
-    double m_epsilon;
-    ibex::Interval m_value;
-};
+        friend bool operator !=(std::pair<ibex::Interval,ibex::Interval> lhs, ApproxIntvPair const& rhs)
+        {
+          return !operator ==(lhs, rhs);
+        }
 
+        friend bool operator !=(ApproxIntvPair const& lhs, std::pair<ibex::Interval,ibex::Interval> rhs)
+        {
+          return !operator ==(rhs, lhs);
+        }
 
-class ApproxIntvPair
-{
-  public:
-    explicit ApproxIntvPair(std::pair<ibex::Interval,ibex::Interval> value) :
-        m_epsilon(std::numeric_limits<float>::epsilon()*10),
-        m_value(value)
-    {}
+        std::string toString() const
+        {
+          std::ostringstream oss;
+          oss << "Approx( " << Catch::toString(m_value.first) << "," << Catch::toString(m_value.second) << " )";
+          return oss.str();
+        }
 
-    friend bool operator ==(std::pair<ibex::Interval,ibex::Interval> lhs, ApproxIntvPair const& rhs)
-    {
-      double e = rhs.m_epsilon;
-      return lhs == rhs.m_value ||
-             (fabs(lhs.first.lb() - rhs.m_value.first.lb()) < e &&
-              fabs(lhs.first.ub() - rhs.m_value.first.ub()) < e &&
-              fabs(lhs.second.lb() - rhs.m_value.second.lb()) < e &&
-              fabs(lhs.second.ub() - rhs.m_value.second.ub()) < e);
-    }
+      private:
+        double m_epsilon;
+        std::pair<ibex::Interval,ibex::Interval> m_value;
+    };
+  }
 
-    friend bool operator ==(ApproxIntvPair const& lhs, std::pair<ibex::Interval,ibex::Interval> rhs)
-    {
-      return operator ==(rhs, lhs);
-    }
+  template<>
+  inline std::string toString<Detail::ApproxIntv>(Detail::ApproxIntv const& value)
+  {
+    return value.toString();
+  }
 
-    friend bool operator !=(std::pair<ibex::Interval,ibex::Interval> lhs, ApproxIntvPair const& rhs)
-    {
-      return !operator ==(lhs, rhs);
-    }
-
-    friend bool operator !=(ApproxIntvPair const& lhs, std::pair<ibex::Interval,ibex::Interval> rhs)
-    {
-      return !operator ==(rhs, lhs);
-    }
-
-  private:
-    double m_epsilon;
-    std::pair<ibex::Interval,ibex::Interval> m_value;
-};
+  template<>
+  inline std::string toString<Detail::ApproxIntvPair>(Detail::ApproxIntvPair const& value)
+  {
+    return value.toString();
+  }
+}

--- a/tests/test_polar.cpp
+++ b/tests/test_polar.cpp
@@ -5,7 +5,8 @@
 #include "ibex_CtcAngle.h"
 
 using namespace ibex;
-
+using namespace Catch;
+using namespace Detail;
 
 bool checkbwd_atan2(const Interval& a, const Interval& y_bef, const Interval& x_bef,
 								const Interval& y_aft, const Interval& x_aft) {


### PR DESCRIPTION
Minor update to display wrong values.

Before:

``` FAILED:
  REQUIRE( ApproxIntv(intv_x) == Interval(-4,4) )
with expansion:
  {?} == [-4, 4]
```

Now:

``` FAILED:
  REQUIRE( ApproxIntv(intv_x) == Interval(-4,4) )
with expansion:
  [-3,3] == [-4, 4]
```
