### PR TITLE
Hotfix 1: CtcSegment successive calls.

### DIFF
--- a/src/polygon/ibex_CtcSegment.cpp
+++ b/src/polygon/ibex_CtcSegment.cpp
@@ -16,12 +16,12 @@ namespace ibex {
 CtcSegment::CtcSegment(double ax, double ay, double bx, double by) : Ctc(2),
     X_with_params(2+4) {
 
-	init();
+    init();
 
-	X_with_params[2] = Interval(ax);
-	X_with_params[3] = Interval(ay);
-	X_with_params[4] = Interval(bx);
-	X_with_params[5] = Interval(by);
+    X_with_params[2] = Interval(ax);
+    X_with_params[3] = Interval(ay);
+    X_with_params[4] = Interval(bx);
+    X_with_params[5] = Interval(by);
 }
 
 CtcSegment::CtcSegment() : Ctc(6), X_with_params(0 /* unused */) {
@@ -29,7 +29,7 @@ CtcSegment::CtcSegment() : Ctc(6), X_with_params(0 /* unused */) {
 }
 
 void CtcSegment::init() {
-	Variable x(2),a(2),b(2);
+    Variable x(2),a(2),b(2);
 
 	Function *f = new Function(x,a,b,(b[0]-a[0])*(a[1]-x[1]) - (b[1]-a[1])*(a[0]-x[0]));
 
@@ -60,19 +60,20 @@ void CtcSegment::contract(IntervalVector &box) {
 		ctc_g->contract(box);
 	}
 	else {
-		X_with_params[0] = box[0];
-		X_with_params[1] = box[1];
-		//        X_with_params=cart_prod(box,)
+        IntervalVector X(X_with_params);
+        X[0] = box[0];
+        X[1] = box[1];
+        //        X_with_params=cart_prod(box,)
 
-		ctc_f->contract(X_with_params);
-		if (X_with_params.is_empty()) { box.set_empty(); return; }
+        ctc_f->contract(X);
+        if (X.is_empty()) { box.set_empty(); return; }
 
-		ctc_g->contract(X_with_params);
-		if (X_with_params.is_empty()) { box.set_empty(); return; }
+        ctc_g->contract(X);
+        if (X.is_empty()) { box.set_empty(); return; }
 
 		//        box = X_with_params.subvector(0,1);
-		box[0] = X_with_params[0];
-		box[1] = X_with_params[1];
+        box[0] = X[0];
+        box[1] = X[1];
 	}
 }
 

--- a/src/polygon/ibex_CtcSegment.h
+++ b/src/polygon/ibex_CtcSegment.h
@@ -58,7 +58,7 @@ public:
 protected:
 	/** Box which contains the box to be contracted and the segment parameters.
 	 * Only used when the segment is fixed.*/
-	IntervalVector X_with_params;
+    IntervalVector X_with_params;
 
 	/** Constraint used by the contractor : the point must belong the the line and
     	to the box which encloses the segment */

--- a/tests/TestCtcSegment.cpp
+++ b/tests/TestCtcSegment.cpp
@@ -98,3 +98,25 @@ TEST_CASE("test_call_with_all_real", "")
     c.contract(box);
     CHECK(box == resbox);
 }
+
+TEST_CASE("test_successive_calls", "")
+{
+    CtcSegment c(0,0,10,10);
+
+
+    IntervalVector box1(2,Interval::ALL_REALS), resbox1(2,Interval(0,10));
+    c.contract(box1);
+    CHECK(box1 == resbox1);
+
+
+
+    IntervalVector box2(2,Interval(-20,-10)), resbox2(2,Interval::EMPTY_SET);
+    c.contract(box2);
+    CHECK(box2 == resbox2);
+
+
+
+    IntervalVector box3(2,Interval::ALL_REALS), resbox3(2,Interval(0,10));
+    c.contract(box3);
+    CHECK(box3 == resbox3);
+}


### PR DESCRIPTION
CtcSegments was not working as expected if the same instance of the contract was called several times.

This problem was forbidding the use of this contract with CtcFixPoint, for instance.